### PR TITLE
Fix ref tag case sensitivity

### DIFF
--- a/conflate/data.py
+++ b/conflate/data.py
@@ -1,4 +1,5 @@
 import math
+from requests.structures import CaseInsensitiveDict
 from . import etree
 
 
@@ -9,8 +10,9 @@ class SourcePoint:
         self.id = str(pid)
         self.lat = lat
         self.lon = lon
-        self.tags = {} if tags is None else {
-            k.lower(): str(v).strip() for k, v in tags.items() if v is not None}
+        self.tags = CaseInsensitiveDict({
+            tag: str(value).strip() for tag, value in tags.items() if value is not None
+        })
         self.category = category
         self.dist_offset = 0
         self.remarks = remarks


### PR DESCRIPTION
At the moment it's not possible to correctly use `ref:` tag keys which contain uppercase characters (I'm not a huge fan of them but it has become common to namespace `ref:` tags with the uppercase country code).

Overpass is case sensitive but osm_conflate currently lowercases all tag  names. This change uses the CaseInsensitiveDict class from `requests` (which is already a dependency) in SourcePoint to avoid tag name case issues.

I've tested this and it now behaves correctly with a ref tag key containing uppercase characters.